### PR TITLE
Added Soul Wars Zeal into the default optional ranks category

### DIFF
--- a/osrs_highscores/resources/categories.py
+++ b/osrs_highscores/resources/categories.py
@@ -37,6 +37,7 @@ default_optional_ranks = [
     "clue_scrolls_elite",
     "clue_scrolls_master",
     "lms_rank",
+    "soul_wars_zeal",
 ]
 
 default_boss_ranks = [


### PR DESCRIPTION
Added "soul_wars_zeal" to default_optional_ranks, which fixes the boss kill count offset experienced since Soul Wars was introduced.